### PR TITLE
fix(posts): 글 본문 폭을 목차 폭에 맞춤

### DIFF
--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -83,8 +83,7 @@ const ogImage = `/og/notes/${noteSlug}.png`;
   }
 
   .article-content {
-    max-width: var(--measure);
-    margin-inline: auto;
+    /* 폭은 .article(--container-narrow)이 결정 — TOC/헤더와 같은 폭으로 정렬 */
     line-height: 1.8;
     color: var(--text-secondary);
     word-break: keep-all;

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -230,8 +230,8 @@ const ogImage = heroImage || `/og/posts/${postSlug}.png`;
   }
 
   .article-content {
-    max-width: var(--measure);
-    margin-inline: auto;
+    /* 폭은 .article(--container-narrow)이 결정 — TOC와 같은 폭으로 정렬.
+       상한 980px 기준 본문 17px에서 한 줄 ~55자로 CPL 범위 안에 들어옵니다. */
     @include body-lg;
     line-height: 1.85;
     color: var(--text-secondary);

--- a/src/pages/reviews/[...slug].astro
+++ b/src/pages/reviews/[...slug].astro
@@ -149,8 +149,7 @@ const ogImage = heroImage || '/profile.png';
   }
 
   .article-content {
-    max-width: var(--measure);
-    margin-inline: auto;
+    /* 폭은 .article(--container-narrow)이 결정 — TOC/헤더와 같은 폭으로 정렬 */
     line-height: 1.8;
     color: var(--text-secondary);
     word-break: keep-all;

--- a/src/styles/base/_tokens.scss
+++ b/src/styles/base/_tokens.scss
@@ -139,7 +139,10 @@
   --container-prose-md: var(--container-sm);
   --container-prose-lg: var(--container-md);
   --container-prose-wide: var(--container-xl);
-  --measure: clamp(38rem, 40vw, 46rem); /* 본문 한 줄 ~45-75 한글 chars, 와이드에서만 완만히 확장 */
+  /* 본문 줄 길이 상한. 소비처는 status/[slug] .incident-body 뿐 —
+     posts/notes/reviews 본문은 컨테이너(--container-narrow)가 폭을 결정합니다.
+     주의: 17px(body-lg) 기준 38rem은 한 줄 ~36자로, CPL 권장 하한(45자)보다 좁습니다. */
+  --measure: clamp(38rem, 40vw, 46rem);
 
   /*
    * Editorial typography scale — 잡지 메타포 전용.


### PR DESCRIPTION
## 문제

`/posts/*` 상세에서 목차(`.toc`)는 `.article` 안쪽 폭을 꽉 채우는데, 본문(`.article-content`)만 `--measure`로 다시 좁혀집니다. 결과적으로 목차 상자보다 본문이 눈에 띄게 좁아 보입니다. #54로 컨테이너가 넓어지면서 이 격차가 더 두드러졌습니다.

## 근거

본문은 `body-lg` = **17px**입니다 (`_typography.scss:66`).

| | 폭 | 한 줄 글자 수 |
|---|---|---|
| 기존 본문 (`--measure` 38rem) | 608px | **~36자** |
| 목차 폭 (`.article` 안쪽, 상한) | 932px | ~55자 |
| CPL 권장 범위 | 765~1275px | 45~75자 |

`--measure` 주석은 "45-75 한글 chars"라고 적혀 있었지만, 17px 기준 실제 값은 36자로 **스스로 명시한 하한에도 못 미쳤습니다**. 목차 폭에 맞추면 ~55자로 오히려 권장 범위 안으로 들어옵니다. 넓히는 쪽이 가독성을 되찾는 방향입니다.

## 변경

- `posts/notes/reviews` 상세의 `.article-content`에서 `max-width: var(--measure)` + `margin-inline: auto` 제거 → 폭을 `.article`(`--container-narrow`)이 결정. 목차와 **구조적으로** 항상 같은 폭이 되어, 컨테이너 값이 바뀌어도 다시 어긋나지 않습니다.
- 상한은 `--container-narrow`의 980px이 그대로 가드레일 역할을 합니다 (~55자). 무한정 넓어지지 않습니다.
- `--measure` 주석의 잘못된 CPL 서술 정정. 이제 소비처는 `status/[slug]` 한 곳뿐입니다.

## 검증

- `pnpm build` 통과 (100 pages). 빌드 산출 CSS에서 `var(--measure)` 소비처가 1곳으로 줄어든 것 확인.
- **브라우저 실물 확인은 하지 않았습니다.** `pnpm dev`로 확인 후 머지해 주세요.

## 후속

`--measure`가 소비처 1곳만 남았고 그마저 부모 `--container-doc`(720px)보다 커질 수 있어 제약이 무효화되는 상태입니다. #54에 적어둔 `--container-doc` fluid화와 함께 정리하는 게 좋겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)