### PR TITLE
refactor(styles): --measure 폐기 + 목록 폭을 --container-doc에서 분리

### DIFF
--- a/src/components/design/_meta.ts
+++ b/src/components/design/_meta.ts
@@ -32,6 +32,6 @@ export const designMeta = {
   date: '2026.05.24',
   isoDate: '2026-05-24',
   version: 'v0.2',
-  tokenCount: 78,             /* +8: --measure, --space-px, --space-0_5/0_75, --container-*, --bp-* */
+  tokenCount: 78,             /* +8: --container-list, --space-px, --space-0_5/0_75, --container-*, --bp-* (--measure 폐기분 상쇄) */
   componentCount: designComponents.length,
 } as const;

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -159,7 +159,7 @@ const notesWithContent = await Promise.all(
   @use '../../styles/abstracts' as *;
 
   .main {
-    max-width: var(--container-doc);
+    max-width: var(--container-list);
     margin: 0 auto;
     padding: var(--space-6);
   }

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -132,7 +132,7 @@ const totalCount = sortedPosts.length;
   @use '../../styles/abstracts' as *;
 
   .main {
-    max-width: var(--container-doc);
+    max-width: var(--container-list);
     margin: 0 auto;
     padding: var(--space-6);
   }

--- a/src/pages/status/[...slug].astro
+++ b/src/pages/status/[...slug].astro
@@ -198,7 +198,8 @@ const timelineStatusColors: Record<string, string> = {
   @use '../../styles/abstracts' as *;
 
   .incident-page {
-    max-width: var(--container-doc);
+    /* 다른 글 상세(posts/notes/reviews)와 동일한 폭 */
+    max-width: var(--container-narrow);
     margin: 0 auto;
     padding: var(--space-8) var(--space-6);
     overflow: hidden;
@@ -492,8 +493,7 @@ const timelineStatusColors: Record<string, string> = {
 
   // Body content
   .incident-body {
-    max-width: var(--measure);
-    margin-inline: auto;
+    /* 폭은 .incident-page(--container-narrow)가 결정 — 헤더/타임라인과 같은 폭으로 정렬 */
     line-height: 1.8;
     color: var(--text-secondary);
     word-break: keep-all;

--- a/src/pages/status/index.astro
+++ b/src/pages/status/index.astro
@@ -182,7 +182,7 @@ function formatTime(d: Date) {
   @use '../../styles/abstracts' as *;
 
   .status-page {
-    max-width: var(--container-doc);
+    max-width: var(--container-list);
     margin: 0 auto;
     padding: var(--space-8) var(--space-6);
   }

--- a/src/styles/base/_tokens.scss
+++ b/src/styles/base/_tokens.scss
@@ -117,7 +117,9 @@
    *   xs  : 480 — 좁은 본문/lede (404 등)
    *   sm  : 700 — 단문 본문 (privacy)
    *   md  : 800 — 중간 본문 (about)
-   *   doc : 720~860 별칭 — 일반 문서/페이지 폭
+   *   doc : 720 고정 — 일반 문서/페이지 폭. design-component TOC가 이 값으로
+   *         위치를 계산(_shell.scss)하므로 fluid로 바꾸지 말 것.
+   *   list: 720~900 — 단일 컬럼 행 목록 (posts/notes/status index)
    *   lg  : 1100 — 그리드/카탈로그 (reviews list)
    *   xl  : 1200 — index 안쪽 컨테이너
    *   2xl : 1400 — 헤더/페이지 최대 폭
@@ -131,6 +133,7 @@
   --container-sm: 700px;
   --container-md: 800px;
   --container-narrow: clamp(780px, 52vw, 980px);
+  --container-list: clamp(720px, 46vw, 900px);
   --container-catalog: clamp(1100px, 72vw, 1440px);
   --container-xl: clamp(1200px, 76vw, 1600px);
   --container-wide: clamp(1400px, 88vw, 1920px);
@@ -139,10 +142,8 @@
   --container-prose-md: var(--container-sm);
   --container-prose-lg: var(--container-md);
   --container-prose-wide: var(--container-xl);
-  /* 본문 줄 길이 상한. 소비처는 status/[slug] .incident-body 뿐 —
-     posts/notes/reviews 본문은 컨테이너(--container-narrow)가 폭을 결정합니다.
-     주의: 17px(body-lg) 기준 38rem은 한 줄 ~36자로, CPL 권장 하한(45자)보다 좁습니다. */
-  --measure: clamp(38rem, 40vw, 46rem);
+  /* --measure 폐기: 17px(body-lg) 기준 38rem은 한 줄 ~36자로 CPL 권장 하한(45자)에도
+     못 미쳐 본문을 불필요하게 좁혔습니다. 본문 줄 길이는 컨테이너 상한이 결정합니다. */
 
   /*
    * Editorial typography scale — 잡지 메타포 전용.


### PR DESCRIPTION
## 배경

#55 이후 `--measure`는 소비처가 `status/[slug] .incident-body` 한 곳만 남았습니다. 그마저 부모 `--container-doc`(720px)보다 커질 수 있어 뷰포트 ~1680px 이상에서 제약으로 동작하지 않는 상태였습니다.

애초에 이 토큰은 17px(`body-lg`) 기준 38rem = 한 줄 **~36자**로, 스스로 명시한 CPL 권장 하한(45자)에도 못 미쳐 본문을 불필요하게 좁히고 있었습니다. 폐기합니다.

## `--container-doc`을 통째로 fluid화하지 않은 이유

조사 결과 이 토큰은 성격이 다른 4부류가 공유하고 있었습니다.

| 부류 | 소비처 | 처리 |
|---|---|---|
| **TOC 위치 계산** | `design-component/_shell.scss:21` | **고정 유지 필수** |
| 산문 문서 | `about`, `contact`, `404`, `design/voice`, `design/changelog` | 고정 유지 |
| 행 목록 | `posts/index`, `notes/index`, `status/index` | → `--container-list` |
| 글 상세 | `status/[slug]` | → `--container-narrow` |

`_shell.scss:21`이 결정적입니다:

```scss
left: max(var(--space-5), calc((100vw - var(--container-doc)) / 2 - var(--toc-gutter)));
```

디자인 컴포넌트 페이지의 TOC가 이 값으로 **위치를 계산**하므로, fluid로 바꾸면 TOC가 함께 움직입니다. (#54 PR 본문에서 제가 "doc은 TOC와 무관하다"고 정정했는데, 그 정정이 틀렸습니다. `--container-spec`뿐 아니라 `--container-doc`도 TOC 레이아웃에 묶여 있었습니다.)

## 변경

- `--container-list: clamp(720px, 46vw, 900px)` 신설. 단일 컬럼 행 목록이라 상한을 900px로 보수적으로 잡았습니다 — catalog(1440px)만큼 넓히면 행이 헐렁해 보입니다.
- `posts/notes/status` index → `--container-list`
- `status/[slug] .incident-page` → `--container-narrow`. 다른 글 상세 3개와 폭이 같아집니다. doc을 넓히는 것보다 정확한 수정입니다.
- `status/[slug] .incident-body`의 `max-width`/`margin-inline` 제거 (#55와 동일 처리)
- `--measure` 토큰 삭제. `--container-doc`은 720px 고정 유지.
- `_meta.ts` tokenCount는 78 유지 — `--measure` 폐기와 `--container-list` 신설이 상쇄됩니다.

## 검증

- `pnpm build` 통과 (100 pages).
- 산출 CSS에 `var(--measure)` **0건** 확인 — dangling 참조 없음.
- `--container-doc` 잔여 소비처 7곳이 전부 TOC 결합부 + 산문 문서임을 확인. 720px 고정이 유지되므로 해당 페이지는 회귀 없음.
- `changelog.astro`의 `--measure` 언급 2건은 v0.2 릴리스 **이력**이라 그대로 뒀습니다 (당시 사실 기록).
- **브라우저 실물 확인은 하지 않았습니다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)